### PR TITLE
Fix how to play button on desktop

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -62,7 +62,7 @@ howToPlayModal.addEventListener('click', (e) => {
 
 // Close modal with Escape key
 document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && howToPlayModal.style.display === 'flex') {
+    if (e.key === 'Escape' && howToPlayModal.classList.contains('show')) {
         hideHowToPlay();
     }
 });
@@ -498,12 +498,14 @@ function hideIndividualResult() {
 }
 
 function showHowToPlay() {
-    howToPlayModal.style.display = 'flex';
-    document.body.style.overflow = 'hidden'; // Prevent background scrolling
+    if (howToPlayModal) {
+        howToPlayModal.classList.add('show');
+        document.body.style.overflow = 'hidden'; // Prevent background scrolling
+    }
 }
 
 function hideHowToPlay() {
-    howToPlayModal.style.display = 'none';
+    howToPlayModal.classList.remove('show');
     document.body.style.overflow = 'auto'; // Restore scrolling
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1789,7 +1789,15 @@ body::before { z-index: -1; }
     justify-content: center;
     z-index: 15000;
     backdrop-filter: blur(15px);
-    animation: modalFadeIn 0.3s ease-out;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
+}
+
+.modal-overlay.show {
+    display: flex !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 }
 
 @keyframes modalFadeIn {
@@ -1942,11 +1950,12 @@ body::before { z-index: -1; }
     font-weight: 600;
 }
 
-/* Mobile modal responsiveness */
+/* ===== MODAL RESPONSIVE STYLES ===== */
 @media (max-width: 768px) {
     .modal-content {
-        width: 95%;
-        max-height: 85vh;
+        max-width: 95%;
+        max-height: 95%;
+        width: auto;
         margin: 10px;
     }
     
@@ -1962,10 +1971,6 @@ body::before { z-index: -1; }
         padding: 20px;
     }
     
-    .rule-section {
-        padding: 15px;
-    }
-    
     .rule-section h3 {
         font-size: 1.2em;
     }
@@ -1975,3 +1980,31 @@ body::before { z-index: -1; }
         font-size: 0.9em;
     }
 }
+
+@media (max-width: 480px) {
+    .modal-content {
+        max-width: 98%;
+        max-height: 98%;
+        margin: 5px;
+    }
+    
+    .modal-header {
+        padding: 12px 15px;
+    }
+    
+    .modal-header h2 {
+        font-size: 1.3em;
+        letter-spacing: 1px;
+    }
+    
+    .modal-body {
+        padding: 15px;
+    }
+    
+    .close-btn {
+        width: 35px;
+        height: 35px;
+        font-size: 1.5em;
+    }
+}
+


### PR DESCRIPTION
Fix 'How to Play' modal not appearing on desktop by switching to CSS class-based display and improving responsiveness.

The previous implementation used inline `style.display = 'flex'` which was unreliable due to CSS specificity issues. This PR introduces a `.show` CSS class with `!important` to reliably control modal visibility and adds responsive styles for better mobile experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fae1c67-172f-4a0e-a997-efda8464dc81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fae1c67-172f-4a0e-a997-efda8464dc81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

