### PR TITLE
Fix desktop how to play button and modal

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -498,14 +498,22 @@ function hideIndividualResult() {
 }
 
 function showHowToPlay() {
+    console.log('showHowToPlay called');
+    console.log('howToPlayModal element:', howToPlayModal);
     if (howToPlayModal) {
+        howToPlayModal.style.display = 'flex';
         howToPlayModal.classList.add('show');
         document.body.style.overflow = 'hidden'; // Prevent background scrolling
+        console.log('Modal should now be visible');
+    } else {
+        console.error('howToPlayModal element not found!');
     }
 }
 
 function hideHowToPlay() {
+    console.log('hideHowToPlay called');
     howToPlayModal.classList.remove('show');
+    howToPlayModal.style.display = 'none';
     document.body.style.overflow = 'auto'; // Restore scrolling
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1792,6 +1792,8 @@ body::before { z-index: -1; }
     visibility: hidden;
     opacity: 0;
     transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
+    overflow-y: auto;
+    padding: 20px;
 }
 
 .modal-overlay.show {
@@ -1810,9 +1812,9 @@ body::before { z-index: -1; }
     border: 2px solid var(--accent-cyan);
     border-radius: 12px;
     max-width: 90%;
-    max-height: 90%;
+    max-height: 90vh;
     width: 700px;
-    overflow-y: auto;
+    overflow: visible;
     animation: modalSlideIn 0.4s cubic-bezier(0.23, 1, 0.32, 1);
     backdrop-filter: blur(20px);
     box-shadow: 
@@ -1878,6 +1880,8 @@ body::before { z-index: -1; }
 .modal-body {
     padding: 30px;
     color: var(--text-primary);
+    overflow: visible;
+    max-height: none;
 }
 
 .game-rules {
@@ -1952,11 +1956,18 @@ body::before { z-index: -1; }
 
 /* ===== MODAL RESPONSIVE STYLES ===== */
 @media (max-width: 768px) {
+    .modal-overlay {
+        padding: 10px;
+        align-items: flex-start;
+        justify-content: center;
+    }
+    
     .modal-content {
         max-width: 95%;
-        max-height: 95%;
+        max-height: none;
         width: auto;
-        margin: 10px;
+        margin: 10px 0;
+        overflow: visible;
     }
     
     .modal-header {
@@ -1969,6 +1980,8 @@ body::before { z-index: -1; }
     
     .modal-body {
         padding: 20px;
+        overflow: visible;
+        max-height: none;
     }
     
     .rule-section h3 {
@@ -1982,10 +1995,15 @@ body::before { z-index: -1; }
 }
 
 @media (max-width: 480px) {
+    .modal-overlay {
+        padding: 5px;
+    }
+    
     .modal-content {
         max-width: 98%;
-        max-height: 98%;
-        margin: 5px;
+        max-height: none;
+        margin: 5px 0;
+        overflow: visible;
     }
     
     .modal-header {
@@ -1999,6 +2017,8 @@ body::before { z-index: -1; }
     
     .modal-body {
         padding: 15px;
+        overflow: visible;
+        max-height: none;
     }
     
     .close-btn {


### PR DESCRIPTION
Fix "How to Play" modal display on desktop and remove internal scrolling.

The modal failed to appear on desktop due to reliance solely on CSS classes for visibility, which was insufficient. Additionally, internal `overflow-y: auto` on modal content caused unwanted scrollbars, which has been replaced by allowing the entire modal overlay to scroll if needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdaf3486-c05c-49ae-aa78-5b472ac62360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdaf3486-c05c-49ae-aa78-5b472ac62360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

