### PR TITLE
Fix modal display on desktop and under screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -218,7 +218,7 @@
     </div>
 
     <!-- How to Play Modal -->
-    <div id="how-to-play-modal" class="modal-overlay" style="display: none;">
+    <div id="how-to-play-modal" class="modal-overlay">
         <div class="modal-content">
             <div class="modal-header">
                 <h2>🎮 HOW TO PLAY</h2>

--- a/public/script.js
+++ b/public/script.js
@@ -501,7 +501,6 @@ function showHowToPlay() {
     console.log('showHowToPlay called');
     console.log('howToPlayModal element:', howToPlayModal);
     if (howToPlayModal) {
-        howToPlayModal.style.display = 'flex';
         howToPlayModal.classList.add('show');
         document.body.style.overflow = 'hidden'; // Prevent background scrolling
         console.log('Modal should now be visible');
@@ -513,7 +512,6 @@ function showHowToPlay() {
 function hideHowToPlay() {
     console.log('hideHowToPlay called');
     howToPlayModal.classList.remove('show');
-    howToPlayModal.style.display = 'none';
     document.body.style.overflow = 'auto'; // Restore scrolling
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1773,6 +1773,7 @@ body::before { z-index: -1; }
         overflow: visible;
         font-size: 0.95em;
     }
+}
 
 /* Duplicate challenge description styles removed - already defined above */
 
@@ -1784,22 +1785,23 @@ body::before { z-index: -1; }
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.85);
-    display: none;
+    display: flex;
     align-items: center;
     justify-content: center;
     z-index: 15000;
     backdrop-filter: blur(15px);
     visibility: hidden;
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
     overflow-y: auto;
     padding: 20px;
 }
 
 .modal-overlay.show {
-    display: flex !important;
     visibility: visible !important;
     opacity: 1 !important;
+    pointer-events: auto !important;
 }
 
 @keyframes modalFadeIn {
@@ -1821,6 +1823,7 @@ body::before { z-index: -1; }
         0 0 50px rgba(0, 245, 255, 0.3),
         var(--shadow-soft);
     position: relative;
+    margin: auto;
 }
 
 @keyframes modalSlideIn {
@@ -2005,26 +2008,31 @@ body::before { z-index: -1; }
         margin: 5px 0;
         overflow: visible;
     }
+}
+
+/* Desktop specific enhancements */
+@media (min-width: 769px) {
+    .modal-overlay {
+        padding: 40px;
+    }
     
-    .modal-header {
-        padding: 12px 15px;
+    .modal-content {
+        width: 800px;
+        max-width: 90vw;
+        max-height: 85vh;
     }
     
     .modal-header h2 {
-        font-size: 1.3em;
-        letter-spacing: 1px;
+        font-size: 2.2em;
     }
     
-    .modal-body {
-        padding: 15px;
-        overflow: visible;
-        max-height: none;
+    .rule-section h3 {
+        font-size: 1.6em;
     }
     
-    .close-btn {
-        width: 35px;
-        height: 35px;
-        font-size: 1.5em;
+    .rule-section p {
+        font-size: 1.1em;
     }
 }
+
 


### PR DESCRIPTION
Fix "How to Play" modal to display as a styled popup on desktop by correcting CSS visibility logic and adding desktop-specific styles.

The modal failed to appear correctly on desktop due to conflicting `display` properties preventing transitions, and a missing CSS brace. This PR refactors the modal's visibility to use `pointer-events` and `opacity` for smooth transitions, updates JavaScript, and introduces dedicated desktop styling for a proper popup experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d3abdb9-bd6e-4a44-878d-1f4f64d2db79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d3abdb9-bd6e-4a44-878d-1f4f64d2db79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

